### PR TITLE
#8: Fix initial population of paged results accumulator in reqwest_impl.rs.

### DIFF
--- a/zotero_api/src/reqwest_impl.rs
+++ b/zotero_api/src/reqwest_impl.rs
@@ -24,7 +24,7 @@ impl ZoteroApiExecutor for http::Request<Bytes> {
 
         let mut next_page = get_next_page(res.headers().clone());
 
-        let response = res
+        let mut response = res
             .json::<Value>()
             .map_err(|err| ZoteroApiError::ParseResponseError(err.to_string()))?;
 
@@ -35,7 +35,14 @@ impl ZoteroApiExecutor for http::Request<Bytes> {
             }
             Some(_) => {
                 let mut responses: Vec<Value> = vec![];
-                responses.push(response);
+
+                let response =
+                    response
+                        .as_array_mut()
+                        .ok_or(ZoteroApiError::ParseResponseError(format!(
+                            "Expected response to be an array."
+                        )))?;
+                responses.append(response);
 
                 // follow pagination if any
                 while let Some(np) = next_page {
@@ -80,7 +87,7 @@ impl ZoteroApiAsyncExecutor for http::Request<Bytes> {
 
         let mut next_page = get_next_page(res.headers().clone());
 
-        let response = res
+        let mut response = res
             .json::<Value>()
             .await
             .map_err(|err| ZoteroApiError::ParseResponseError(err.to_string()))?;
@@ -92,7 +99,14 @@ impl ZoteroApiAsyncExecutor for http::Request<Bytes> {
             }
             Some(_) => {
                 let mut responses: Vec<Value> = vec![];
-                responses.push(response);
+
+                let response =
+                    response
+                        .as_array_mut()
+                        .ok_or(ZoteroApiError::ParseResponseError(format!(
+                            "Expected response to be an array."
+                        )))?;
+                responses.append(response);
 
                 // follow pagination if any
                 while let Some(np) = next_page {


### PR DESCRIPTION
See #8 for a description of the error. 

This enforces that, in the paged scendario, `response` is a `Value::Array(Vec<Value>)` before proceeding with processing. If it is not an `Array`, then it bails with an error.

The alternative would be to be more permissive, and unwrap `response` if it is an array (as this change currently does), but fall back on just pushing `response` to the first position of `responses` if it is not (which is the current code's behavior). 

I don't _see_ a case where paging would happen outside of an array context, so I've chosen the more more restrictive behavior. That may not be appropriate though, so I'm happy to switch to more permissive logic.

Note that all tests pass with this fix in, however, this particular leg doesn't seem to be covered in the integration tests. I have, however, verified that it works for me, locally, hitting the public Zotero api for groups.

